### PR TITLE
Make bench runner worker thread compatible.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,105 +46,108 @@ $ DEBUG=ssr:timer yarn benchmark
 * os: darwin 18.7.0 x64
 * cpus: 4
 * node: v8.10.0
+* execution: child process
 
 | Demo  | Conc | Args | Impl       | M loops | W time | W result |
 | :---- | ---: | ---: | :--------- | ------: | -----: | -------: |
-| react |    1 |    1 | sync       |       1 |     23 |     pass |
-| react |    1 |    1 | jest       |      75 |    119 |     pass |
-| react |    1 |    1 | workerpool |      63 |     89 |     pass |
-| react |    1 |   5K | sync       |       1 |     60 |     pass |
-| react |    1 |   5K | jest       |     114 |    147 |     pass |
-| react |    1 |   5K | workerpool |     128 |    195 |     pass |
-| react |    1 |  50K | sync       |       1 |   1402 |     pass |
-| react |    1 |  50K | jest       |    1066 |   1413 |     pass |
-| react |    1 |  50K | workerpool |    1103 |   1488 |     pass |
+| react |    1 |    1 | sync       |       1 |     21 |     pass |
+| react |    1 |    1 | jest       |      91 |    142 |     pass |
+| react |    1 |    1 | workerpool |      86 |    124 |     pass |
+| react |    1 |   5K | sync       |       1 |     67 |     pass |
+| react |    1 |   5K | jest       |     185 |    266 |     pass |
+| react |    1 |   5K | workerpool |     137 |    181 |     pass |
+| react |    1 |  50K | sync       |       1 |   1357 |     pass |
+| react |    1 |  50K | jest       |    1348 |   1777 |     pass |
+| react |    1 |  50K | workerpool |    1217 |   1651 |     pass |
 | react |    2 |    1 | sync       |       1 |      0 |     pass |
-| react |    2 |    1 | jest       |      69 |     97 |     pass |
-| react |    2 |    1 | workerpool |      69 |     98 |     pass |
-| react |    2 |   5K | sync       |       1 |     47 |     pass |
-| react |    2 |   5K | jest       |     146 |    195 |     pass |
-| react |    2 |   5K | workerpool |     150 |    195 |     pass |
-| react |    2 |  50K | sync       |       1 |   2529 |     pass |
-| react |    2 |  50K | jest       |    1398 |   1883 |     pass |
-| react |    2 |  50K | workerpool |    1451 |   1938 |     pass |
-| react |    4 |    1 | sync       |       1 |      1 |     pass |
-| react |    4 |    1 | jest       |      58 |    232 |     pass |
-| react |    4 |    1 | workerpool |      17 |    182 |     pass |
-| react |    4 |   5K | sync       |       1 |    119 |     pass |
-| react |    4 |   5K | jest       |     160 |    414 |     pass |
-| react |    4 |   5K | workerpool |     191 |    425 |     pass |
-| react |    4 |  50K | sync       |       1 |   5447 |     pass |
-| react |    4 |  50K | jest       |    2654 |   3958 |     pass |
-| react |    4 |  50K | workerpool |    2903 |   4342 |     pass |
+| react |    2 |    1 | jest       |      75 |    103 |     pass |
+| react |    2 |    1 | workerpool |      73 |     98 |     pass |
+| react |    2 |   5K | sync       |       1 |     46 |     pass |
+| react |    2 |   5K | jest       |     140 |    193 |     pass |
+| react |    2 |   5K | workerpool |     148 |    189 |     pass |
+| react |    2 |  50K | sync       |       1 |   2538 |     pass |
+| react |    2 |  50K | jest       |    1342 |   1844 |     pass |
+| react |    2 |  50K | workerpool |    1670 |   2426 |     pass |
+| react |    4 |    1 | sync       |       1 |      0 |     pass |
+| react |    4 |    1 | jest       |      64 |    177 |     pass |
+| react |    4 |    1 | workerpool |      22 |    179 |     pass |
+| react |    4 |   5K | sync       |       1 |    112 |     pass |
+| react |    4 |   5K | jest       |     105 |    348 |     pass |
+| react |    4 |   5K | workerpool |     183 |    373 |     pass |
+| react |    4 |  50K | sync       |       1 |   5304 |     pass |
+| react |    4 |  50K | jest       |    2534 |   3531 |     pass |
+| react |    4 |  50K | workerpool |    2797 |   4022 |     pass |
 
 ### Node 10
 
 * os: darwin 18.7.0 x64
 * cpus: 4
 * node: v10.16.3
+* execution: child process
 
 | Demo  | Conc | Args | Impl       | M loops | W time | W result |
 | :---- | ---: | ---: | :--------- | ------: | -----: | -------: |
-| react |    1 |    1 | sync       |       1 |     21 |     pass |
-| react |    1 |    1 | jest       |      78 |    111 |     pass |
-| react |    1 |    1 | workerpool |      80 |    111 |     pass |
-| react |    1 |   5K | sync       |       1 |     61 |     pass |
-| react |    1 |   5K | jest       |     132 |    170 |     pass |
-| react |    1 |   5K | workerpool |     154 |    201 |     pass |
-| react |    1 |  50K | sync       |       1 |   1191 |     pass |
-| react |    1 |  50K | jest       |    1128 |   1479 |     pass |
-| react |    1 |  50K | workerpool |    1110 |   1486 |     pass |
+| react |    1 |    1 | sync       |       1 |     22 |     pass |
+| react |    1 |    1 | jest       |      81 |    123 |     pass |
+| react |    1 |    1 | workerpool |      77 |    104 |     pass |
+| react |    1 |   5K | sync       |       1 |     59 |     pass |
+| react |    1 |   5K | jest       |     152 |    196 |     pass |
+| react |    1 |   5K | workerpool |     131 |    169 |     pass |
+| react |    1 |  50K | sync       |       1 |   1523 |     pass |
+| react |    1 |  50K | jest       |    1056 |   1567 |     pass |
+| react |    1 |  50K | workerpool |    1430 |   1914 |     pass |
 | react |    2 |    1 | sync       |       1 |      0 |     pass |
-| react |    2 |    1 | jest       |      92 |    130 |     pass |
-| react |    2 |    1 | workerpool |      96 |    125 |     pass |
-| react |    2 |   5K | sync       |       1 |     43 |     pass |
-| react |    2 |   5K | jest       |     167 |    233 |     pass |
-| react |    2 |   5K | workerpool |     205 |    265 |     pass |
-| react |    2 |  50K | sync       |       1 |   2477 |     pass |
-| react |    2 |  50K | jest       |    1552 |   2123 |     pass |
-| react |    2 |  50K | workerpool |    1504 |   2152 |     pass |
+| react |    2 |    1 | jest       |      94 |    145 |     pass |
+| react |    2 |    1 | workerpool |      87 |    113 |     pass |
+| react |    2 |   5K | sync       |       1 |     39 |     pass |
+| react |    2 |   5K | jest       |     152 |    282 |     pass |
+| react |    2 |   5K | workerpool |     328 |    467 |     pass |
+| react |    2 |  50K | sync       |       1 |   2769 |     pass |
+| react |    2 |  50K | jest       |    2285 |   3320 |     pass |
+| react |    2 |  50K | workerpool |    2416 |   4040 |     pass |
 | react |    4 |    1 | sync       |       1 |      0 |     pass |
-| react |    4 |    1 | jest       |       5 |    597 |     pass |
-| react |    4 |    1 | workerpool |     114 |    271 |     pass |
-| react |    4 |   5K | sync       |       1 |    111 |     pass |
-| react |    4 |   5K | jest       |     130 |    421 |     pass |
-| react |    4 |   5K | workerpool |     202 |    446 |     pass |
-| react |    4 |  50K | sync       |       1 |   5932 |     pass |
-| react |    4 |  50K | jest       |    3005 |   4205 |     pass |
-| react |    4 |  50K | workerpool |    3070 |   4654 |     pass |
+| react |    4 |    1 | jest       |     191 |    291 |     pass |
+| react |    4 |    1 | workerpool |     104 |    258 |     pass |
+| react |    4 |   5K | sync       |       1 |    152 |     pass |
+| react |    4 |   5K | jest       |     254 |    578 |     pass |
+| react |    4 |   5K | workerpool |     350 |    604 |     pass |
+| react |    4 |  50K | sync       |       1 |   7433 |     pass |
+| react |    4 |  50K | jest       |    3980 |   5797 |     pass |
+| react |    4 |  50K | workerpool |    4050 |   6251 |     pass |
 
 ### Node 12
 
 * os: darwin 18.7.0 x64
 * cpus: 4
 * node: v12.11.0
+* execution: worker thread
 
 | Demo  | Conc | Args | Impl       | M loops | W time | W result |
 | :---- | ---: | ---: | :--------- | ------: | -----: | -------: |
-| react |    1 |    1 | sync       |       1 |     12 |     pass |
-| react |    1 |    1 | jest       |      30 |     62 |     pass |
-| react |    1 |    1 | workerpool |      39 |     62 |     pass |
-| react |    1 |   5K | sync       |       1 |     74 |     pass |
-| react |    1 |   5K | jest       |      85 |    125 |     pass |
-| react |    1 |   5K | workerpool |      71 |    123 |     pass |
-| react |    1 |  50K | sync       |       1 |   1107 |     pass |
-| react |    1 |  50K | jest       |    1257 |   1839 |     pass |
-| react |    1 |  50K | workerpool |    1204 |   1643 |     pass |
+| react |    1 |    1 | sync       |       1 |     11 |     pass |
+| react |    1 |    1 | jest       |      30 |     47 |     pass |
+| react |    1 |    1 | workerpool |      29 |     40 |     pass |
+| react |    1 |   5K | sync       |       1 |     75 |     pass |
+| react |    1 |   5K | jest       |      70 |    108 |     pass |
+| react |    1 |   5K | workerpool |      54 |    100 |     pass |
+| react |    1 |  50K | sync       |       1 |   1005 |     pass |
+| react |    1 |  50K | jest       |     805 |   1152 |     pass |
+| react |    1 |  50K | workerpool |     870 |   1177 |     pass |
 | react |    2 |    1 | sync       |       1 |      0 |     pass |
-| react |    2 |    1 | jest       |      25 |     84 |     pass |
-| react |    2 |    1 | workerpool |      42 |     69 |     pass |
-| react |    2 |   5K | sync       |       1 |     47 |     pass |
-| react |    2 |   5K | jest       |      13 |    178 |     pass |
-| react |    2 |   5K | workerpool |      87 |    168 |     pass |
-| react |    2 |  50K | sync       |       1 |   2157 |     pass |
-| react |    2 |  50K | jest       |    1219 |   1914 |     pass |
-| react |    2 |  50K | workerpool |    1525 |   2231 |     pass |
+| react |    2 |    1 | jest       |      18 |     43 |     pass |
+| react |    2 |    1 | workerpool |      13 |     63 |     pass |
+| react |    2 |   5K | sync       |       1 |     44 |     pass |
+| react |    2 |   5K | jest       |      13 |    134 |     pass |
+| react |    2 |   5K | workerpool |      41 |    139 |     pass |
+| react |    2 |  50K | sync       |       1 |   1905 |     pass |
+| react |    2 |  50K | jest       |    1697 |   2344 |     pass |
+| react |    2 |  50K | workerpool |    1891 |   2595 |     pass |
 | react |    4 |    1 | sync       |       1 |      0 |     pass |
-| react |    4 |    1 | jest       |      33 |    187 |     pass |
-| react |    4 |    1 | workerpool |       6 |    189 |     pass |
-| react |    4 |   5K | sync       |       1 |    129 |     pass |
-| react |    4 |   5K | jest       |     134 |    495 |     pass |
-| react |    4 |   5K | workerpool |     158 |    441 |     pass |
-| react |    4 |  50K | sync       |       1 |   4944 |     pass |
-| react |    4 |  50K | jest       |    2779 |   4206 |     pass |
-| react |    4 |  50K | workerpool |    2774 |   4390 |     pass |
+| react |    4 |    1 | jest       |      49 |    133 |     pass |
+| react |    4 |    1 | workerpool |      36 |    103 |     pass |
+| react |    4 |   5K | sync       |       1 |     96 |     pass |
+| react |    4 |   5K | jest       |      77 |    380 |     pass |
+| react |    4 |   5K | workerpool |     192 |    410 |     pass |
+| react |    4 |  50K | sync       |       1 |   6743 |     pass |
+| react |    4 |  50K | jest       |    4657 |   6640 |     pass |
+| react |    4 |  50K | workerpool |    4473 |   6099 |     pass |

--- a/benchmark/impl/jest-worker/index.js
+++ b/benchmark/impl/jest-worker/index.js
@@ -38,11 +38,8 @@ module.exports = async ({ conc, worker, args }) => {
   }
 
   const workerFn = new Worker(require.resolve(worker), {
-    numWorkers: conc
-    // TODO: This currently fails on Node12 with DataCloneError.
-    // https://github.com/FormidableLabs/ssr-experiments/issues/3
-    // Currently _does_ work on node10 with `yarn benchmark --experimental-worker`
-    // , enableWorkerThreads: true // use workers if available
+    numWorkers: conc,
+    enableWorkerThreads: true // use workers if available
   });
 
   const concArr = Array.from(new Array(conc));

--- a/benchmark/impl/workerpool/index.js
+++ b/benchmark/impl/workerpool/index.js
@@ -33,11 +33,7 @@ module.exports = async ({ conc, worker, args }) => {
 
   const pool = workerpool.pool({
     minWorkers: conc,
-    maxWorkers: conc,
-    // TODO: This currently fails on Node12 with DataCloneError.
-    // https://github.com/FormidableLabs/ssr-experiments/issues/3
-    // Remove this hard-code setting when fixed.
-    workerType: "process"
+    maxWorkers: conc
   });
 
   const concArr = Array.from(new Array(conc));


### PR DESCRIPTION
- Fix parameters to worker threads (cannot be functions). Fixes #3 
- Add worker thread / child process report indicator
- Add new benchmark run info

/cc @kevinmstephens @tptee 