### PR TITLE
Feature: Add timings _within_ the worker proc/thread

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ $ DEBUG=ssr:timer yarn benchmark
 * Conc: Level of concurrency _and_ number of executions
 * Args: Options passed to worker (e.g. "number of times to repeat")
 * M loops: Main thread loops on 1ms timer (bigger is better)
-* W time: Worker elapsed time (smaller is better)
+* WI time: Single worker average "inner" time inside worker (smaller is better)
+* WO time: Total worker "outer" time across worker (smaller is better)
 * W result: Correctness vs synchronous baseline
 
 ### Node 8
@@ -48,35 +49,35 @@ $ DEBUG=ssr:timer yarn benchmark
 * node: v8.10.0
 * execution: child process
 
-| Demo  | Conc | Args | Impl       | M loops | W time | W result |
-| :---- | ---: | ---: | :--------- | ------: | -----: | -------: |
-| react |    1 |    1 | sync       |       1 |     21 |     pass |
-| react |    1 |    1 | jest       |      91 |    142 |     pass |
-| react |    1 |    1 | workerpool |      86 |    124 |     pass |
-| react |    1 |   5K | sync       |       1 |     67 |     pass |
-| react |    1 |   5K | jest       |     185 |    266 |     pass |
-| react |    1 |   5K | workerpool |     137 |    181 |     pass |
-| react |    1 |  50K | sync       |       1 |   1357 |     pass |
-| react |    1 |  50K | jest       |    1348 |   1777 |     pass |
-| react |    1 |  50K | workerpool |    1217 |   1651 |     pass |
-| react |    2 |    1 | sync       |       1 |      0 |     pass |
-| react |    2 |    1 | jest       |      75 |    103 |     pass |
-| react |    2 |    1 | workerpool |      73 |     98 |     pass |
-| react |    2 |   5K | sync       |       1 |     46 |     pass |
-| react |    2 |   5K | jest       |     140 |    193 |     pass |
-| react |    2 |   5K | workerpool |     148 |    189 |     pass |
-| react |    2 |  50K | sync       |       1 |   2538 |     pass |
-| react |    2 |  50K | jest       |    1342 |   1844 |     pass |
-| react |    2 |  50K | workerpool |    1670 |   2426 |     pass |
-| react |    4 |    1 | sync       |       1 |      0 |     pass |
-| react |    4 |    1 | jest       |      64 |    177 |     pass |
-| react |    4 |    1 | workerpool |      22 |    179 |     pass |
-| react |    4 |   5K | sync       |       1 |    112 |     pass |
-| react |    4 |   5K | jest       |     105 |    348 |     pass |
-| react |    4 |   5K | workerpool |     183 |    373 |     pass |
-| react |    4 |  50K | sync       |       1 |   5304 |     pass |
-| react |    4 |  50K | jest       |    2534 |   3531 |     pass |
-| react |    4 |  50K | workerpool |    2797 |   4022 |     pass |
+| Demo  | Conc | Args | Impl       | M loops | WI time | WO time | W result |
+| :---- | ---: | ---: | :--------- | ------: | ------: | ------: | -------- |
+| react |    1 |    1 | sync       |       1 |       7 |      19 | pass     |
+| react |    1 |    1 | jest       |      82 |      12 |     119 | pass     |
+| react |    1 |    1 | workerpool |      80 |       5 |     112 | pass     |
+| react |    1 |   5K | sync       |       1 |      60 |      60 | pass     |
+| react |    1 |   5K | jest       |     118 |      64 |     151 | pass     |
+| react |    1 |   5K | workerpool |     120 |      66 |     156 | pass     |
+| react |    1 |  50K | sync       |       1 |    1265 |    1265 | pass     |
+| react |    1 |  50K | jest       |    1169 |    1341 |    1519 | pass     |
+| react |    1 |  50K | workerpool |    1167 |    1318 |    1496 | pass     |
+| react |    2 |    1 | sync       |       1 |       0 |       0 | pass     |
+| react |    2 |    1 | jest       |      75 |       5 |     117 | pass     |
+| react |    2 |    1 | workerpool |      77 |       6 |     122 | pass     |
+| react |    2 |   5K | sync       |       1 |      17 |      36 | pass     |
+| react |    2 |   5K | jest       |     106 |      79 |     184 | pass     |
+| react |    2 |   5K | workerpool |     121 |      83 |     183 | pass     |
+| react |    2 |  50K | sync       |       1 |    1210 |    2421 | pass     |
+| react |    2 |  50K | jest       |    1347 |    1672 |    1940 | pass     |
+| react |    2 |  50K | workerpool |    1610 |    1845 |    2163 | pass     |
+| react |    4 |    1 | sync       |       1 |       0 |       0 | pass     |
+| react |    4 |    1 | jest       |     120 |      11 |     214 | pass     |
+| react |    4 |    1 | workerpool |      87 |       9 |     206 | pass     |
+| react |    4 |   5K | sync       |       1 |      31 |     125 | pass     |
+| react |    4 |   5K | jest       |     158 |     188 |     429 | pass     |
+| react |    4 |   5K | workerpool |     198 |     214 |     452 | pass     |
+| react |    4 |  50K | sync       |       1 |    1612 |    6450 | pass     |
+| react |    4 |  50K | jest       |    3207 |    4250 |    4979 | pass     |
+| react |    4 |  50K | workerpool |    3200 |    4343 |    4905 | pass     |
 
 ### Node 10
 
@@ -85,35 +86,35 @@ $ DEBUG=ssr:timer yarn benchmark
 * node: v10.16.3
 * execution: child process
 
-| Demo  | Conc | Args | Impl       | M loops | W time | W result |
-| :---- | ---: | ---: | :--------- | ------: | -----: | -------: |
-| react |    1 |    1 | sync       |       1 |     22 |     pass |
-| react |    1 |    1 | jest       |      81 |    123 |     pass |
-| react |    1 |    1 | workerpool |      77 |    104 |     pass |
-| react |    1 |   5K | sync       |       1 |     59 |     pass |
-| react |    1 |   5K | jest       |     152 |    196 |     pass |
-| react |    1 |   5K | workerpool |     131 |    169 |     pass |
-| react |    1 |  50K | sync       |       1 |   1523 |     pass |
-| react |    1 |  50K | jest       |    1056 |   1567 |     pass |
-| react |    1 |  50K | workerpool |    1430 |   1914 |     pass |
-| react |    2 |    1 | sync       |       1 |      0 |     pass |
-| react |    2 |    1 | jest       |      94 |    145 |     pass |
-| react |    2 |    1 | workerpool |      87 |    113 |     pass |
-| react |    2 |   5K | sync       |       1 |     39 |     pass |
-| react |    2 |   5K | jest       |     152 |    282 |     pass |
-| react |    2 |   5K | workerpool |     328 |    467 |     pass |
-| react |    2 |  50K | sync       |       1 |   2769 |     pass |
-| react |    2 |  50K | jest       |    2285 |   3320 |     pass |
-| react |    2 |  50K | workerpool |    2416 |   4040 |     pass |
-| react |    4 |    1 | sync       |       1 |      0 |     pass |
-| react |    4 |    1 | jest       |     191 |    291 |     pass |
-| react |    4 |    1 | workerpool |     104 |    258 |     pass |
-| react |    4 |   5K | sync       |       1 |    152 |     pass |
-| react |    4 |   5K | jest       |     254 |    578 |     pass |
-| react |    4 |   5K | workerpool |     350 |    604 |     pass |
-| react |    4 |  50K | sync       |       1 |   7433 |     pass |
-| react |    4 |  50K | jest       |    3980 |   5797 |     pass |
-| react |    4 |  50K | workerpool |    4050 |   6251 |     pass |
+| Demo  | Conc | Args | Impl       | M loops | WI time | WO time | W result |
+| :---- | ---: | ---: | :--------- | ------: | ------: | ------: | -------- |
+| react |    1 |    1 | sync       |       1 |       9 |      25 | pass     |
+| react |    1 |    1 | jest       |      90 |       6 |     140 | pass     |
+| react |    1 |    1 | workerpool |      91 |       7 |     129 | pass     |
+| react |    1 |   5K | sync       |       1 |      64 |      64 | pass     |
+| react |    1 |   5K | jest       |     135 |      65 |     177 | pass     |
+| react |    1 |   5K | workerpool |     152 |      70 |     194 | pass     |
+| react |    1 |  50K | sync       |       1 |    1313 |    1313 | pass     |
+| react |    1 |  50K | jest       |    1030 |    1275 |    1472 | pass     |
+| react |    1 |  50K | workerpool |    1067 |    1234 |    1485 | pass     |
+| react |    2 |    1 | sync       |       1 |       0 |       0 | pass     |
+| react |    2 |    1 | jest       |      78 |       7 |     160 | pass     |
+| react |    2 |    1 | workerpool |      73 |       8 |     134 | pass     |
+| react |    2 |   5K | sync       |       1 |      21 |      43 | pass     |
+| react |    2 |   5K | jest       |     145 |      90 |     215 | pass     |
+| react |    2 |   5K | workerpool |     161 |     119 |     251 | pass     |
+| react |    2 |  50K | sync       |       1 |    1196 |    2393 | pass     |
+| react |    2 |  50K | jest       |    1412 |    1807 |    2089 | pass     |
+| react |    2 |  50K | workerpool |    1575 |    2169 |    2545 | pass     |
+| react |    4 |    1 | sync       |       1 |       0 |       0 | pass     |
+| react |    4 |    1 | jest       |     172 |      12 |     291 | pass     |
+| react |    4 |    1 | workerpool |     120 |      12 |     259 | pass     |
+| react |    4 |   5K | sync       |       1 |      29 |     118 | pass     |
+| react |    4 |   5K | jest       |     159 |     232 |     490 | pass     |
+| react |    4 |   5K | workerpool |     187 |     206 |     511 | pass     |
+| react |    4 |  50K | sync       |       1 |    1451 |    5806 | pass     |
+| react |    4 |  50K | jest       |    3055 |    3853 |    4344 | pass     |
+| react |    4 |  50K | workerpool |    3073 |    3985 |    4549 | pass     |
 
 ### Node 12
 
@@ -122,32 +123,32 @@ $ DEBUG=ssr:timer yarn benchmark
 * node: v12.11.0
 * execution: worker thread
 
-| Demo  | Conc | Args | Impl       | M loops | W time | W result |
-| :---- | ---: | ---: | :--------- | ------: | -----: | -------: |
-| react |    1 |    1 | sync       |       1 |     11 |     pass |
-| react |    1 |    1 | jest       |      30 |     47 |     pass |
-| react |    1 |    1 | workerpool |      29 |     40 |     pass |
-| react |    1 |   5K | sync       |       1 |     75 |     pass |
-| react |    1 |   5K | jest       |      70 |    108 |     pass |
-| react |    1 |   5K | workerpool |      54 |    100 |     pass |
-| react |    1 |  50K | sync       |       1 |   1005 |     pass |
-| react |    1 |  50K | jest       |     805 |   1152 |     pass |
-| react |    1 |  50K | workerpool |     870 |   1177 |     pass |
-| react |    2 |    1 | sync       |       1 |      0 |     pass |
-| react |    2 |    1 | jest       |      18 |     43 |     pass |
-| react |    2 |    1 | workerpool |      13 |     63 |     pass |
-| react |    2 |   5K | sync       |       1 |     44 |     pass |
-| react |    2 |   5K | jest       |      13 |    134 |     pass |
-| react |    2 |   5K | workerpool |      41 |    139 |     pass |
-| react |    2 |  50K | sync       |       1 |   1905 |     pass |
-| react |    2 |  50K | jest       |    1697 |   2344 |     pass |
-| react |    2 |  50K | workerpool |    1891 |   2595 |     pass |
-| react |    4 |    1 | sync       |       1 |      0 |     pass |
-| react |    4 |    1 | jest       |      49 |    133 |     pass |
-| react |    4 |    1 | workerpool |      36 |    103 |     pass |
-| react |    4 |   5K | sync       |       1 |     96 |     pass |
-| react |    4 |   5K | jest       |      77 |    380 |     pass |
-| react |    4 |   5K | workerpool |     192 |    410 |     pass |
-| react |    4 |  50K | sync       |       1 |   6743 |     pass |
-| react |    4 |  50K | jest       |    4657 |   6640 |     pass |
-| react |    4 |  50K | workerpool |    4473 |   6099 |     pass |
+| Demo  | Conc | Args | Impl       | M loops | WI time | WO time | W result |
+| :---- | ---: | ---: | :--------- | ------: | ------: | ------: | -------- |
+| react |    1 |    1 | sync       |       1 |       4 |      12 | pass     |
+| react |    1 |    1 | jest       |      32 |       3 |      53 | pass     |
+| react |    1 |    1 | workerpool |      43 |       4 |      58 | pass     |
+| react |    1 |   5K | sync       |       1 |      68 |      68 | pass     |
+| react |    1 |   5K | jest       |      35 |      68 |     126 | pass     |
+| react |    1 |   5K | workerpool |      80 |      76 |     120 | pass     |
+| react |    1 |  50K | sync       |       1 |    1139 |    1139 | pass     |
+| react |    1 |  50K | jest       |     914 |    1307 |    1381 | pass     |
+| react |    1 |  50K | workerpool |     826 |    1289 |    1370 | pass     |
+| react |    2 |    1 | sync       |       1 |       0 |       0 | pass     |
+| react |    2 |    1 | jest       |      22 |       4 |      64 | pass     |
+| react |    2 |    1 | workerpool |      19 |       4 |      55 | pass     |
+| react |    2 |   5K | sync       |       1 |      28 |      58 | pass     |
+| react |    2 |   5K | jest       |      44 |     102 |     158 | pass     |
+| react |    2 |   5K | workerpool |      50 |     115 |     168 | pass     |
+| react |    2 |  50K | sync       |       1 |    1082 |    2164 | pass     |
+| react |    2 |  50K | jest       |    1870 |    2387 |    2585 | pass     |
+| react |    2 |  50K | workerpool |    2333 |    2922 |    3255 | pass     |
+| react |    4 |    1 | sync       |       1 |       0 |       0 | pass     |
+| react |    4 |    1 | jest       |      93 |       9 |     260 | pass     |
+| react |    4 |    1 | workerpool |      13 |      26 |     218 | pass     |
+| react |    4 |   5K | sync       |       1 |      29 |     123 | pass     |
+| react |    4 |   5K | jest       |      95 |     231 |     537 | pass     |
+| react |    4 |   5K | workerpool |     303 |     307 |     615 | pass     |
+| react |    4 |  50K | sync       |       1 |    1638 |    6556 | pass     |
+| react |    4 |  50K | jest       |    2710 |    3678 |    4146 | pass     |
+| react |    4 |  50K | workerpool |    3174 |    4005 |    4344 | pass     |

--- a/benchmark/runner/index.js
+++ b/benchmark/runner/index.js
@@ -118,8 +118,8 @@ const benchmark = module.exports = () => Promise.resolve()
             process.stdout.write("."); // progress indicator
             workDone = true;
             return {
-              // Use _first_ result as inner elapsed
-              innerElapsed: data.result.elapsed[0],
+              // Inner is _average_ of array values
+              innerElapsed: data.result.reduce((m, r) => m + r.elapsed, 0) / data.result.length,
               outerElapsed: data.elapsed,
               result: data.result.map((r) => r.result)
             };
@@ -175,7 +175,7 @@ const benchmark = module.exports = () => Promise.resolve()
         cyan(args.name),
         magenta(impl),
         main,
-        work.innerElapsed,
+        Math.floor(work.innerElapsed),
         work.outerElapsed,
         isCorrect ? green("pass") : red("fail")
       ]);
@@ -197,8 +197,8 @@ const benchmark = module.exports = () => Promise.resolve()
 * {cyan Conc}: Level of concurrency _and_ number of executions
 * {cyan Args}: Options passed to worker (e.g. "number of times to repeat")
 * {cyan M loops}: Main thread loops on 1ms timer ({green bigger} is better)
-* {cyan WI time}: Worker "inner" elapsed time within worker ({green smaller} is better)
-* {cyan WO time}: Worker "outer" elapsed time across worker ({green smaller} is better)
+* {cyan WI time}: Single worker average "inner" time inside worker ({green smaller} is better)
+* {cyan WO time}: Total worker "outer" time across worker ({green smaller} is better)
 * {cyan W result}: Correctness vs synchronous baseline
 
 {gray ### Results}

--- a/benchmark/runner/index.js
+++ b/benchmark/runner/index.js
@@ -118,8 +118,10 @@ const benchmark = module.exports = () => Promise.resolve()
             process.stdout.write("."); // progress indicator
             workDone = true;
             return {
-              elapsed: data.elapsed,
-              result: data.result
+              // Use _first_ result as inner elapsed
+              innerElapsed: data.result.elapsed[0],
+              outerElapsed: data.elapsed,
+              result: data.result.map((r) => r.result)
             };
           }),
 
@@ -137,7 +139,7 @@ const benchmark = module.exports = () => Promise.resolve()
     })
   ))
   .then((results) => {
-    const HEADER = ["Demo", "Conc", "Args", "Impl", "M loops", "W time", "W result"]
+    const HEADER = ["Demo", "Conc", "Args", "Impl", "M loops", "WI time", "WO time", "W result"]
       .map((t) => gray(t));
     const tableData = [HEADER];
 
@@ -173,7 +175,8 @@ const benchmark = module.exports = () => Promise.resolve()
         cyan(args.name),
         magenta(impl),
         main,
-        work.elapsed,
+        work.innerElapsed,
+        work.outerElapsed,
         isCorrect ? green("pass") : red("fail")
       ]);
     });
@@ -194,7 +197,8 @@ const benchmark = module.exports = () => Promise.resolve()
 * {cyan Conc}: Level of concurrency _and_ number of executions
 * {cyan Args}: Options passed to worker (e.g. "number of times to repeat")
 * {cyan M loops}: Main thread loops on 1ms timer ({green bigger} is better)
-* {cyan W time}: Worker elapsed time ({green smaller} is better)
+* {cyan WI time}: Worker "inner" elapsed time within worker ({green smaller} is better)
+* {cyan WO time}: Worker "outer" elapsed time across worker ({green smaller} is better)
 * {cyan W result}: Correctness vs synchronous baseline
 
 {gray ### Results}

--- a/benchmark/scenarios/react/index.js
+++ b/benchmark/scenarios/react/index.js
@@ -3,6 +3,8 @@
 const { createElement } = require("react");
 const { renderToString } = require("react-dom/server");
 
+const { timer } = require("../../lib/util");
+
 const randomColor = () => // eslint-disable-next-line no-magic-numbers, prefer-template
   "#" + ("00000" + Math.floor(Math.random() * 0x1000000).toString(16)).substr(-6);
 
@@ -29,12 +31,12 @@ const Component = ({ repeat }) => (new Array(repeat)).fill(null).map(() => creat
  *
  * @param {Object} opts         options object
  * @param {Number} opts.repeat  number of times to repeat string.
- * @returns {Promise}           string result in a promise
+ * @returns {Promise}           `{ result<string>, elapsed<Number> }` in a promise
  */
-const render = (opts) => Promise.resolve()
+const render = (opts) => timer(() => Promise.resolve()
   .then(() => renderToString(createElement(Component, {
     repeat: opts.repeat
-  })));
+  }))));
 
 module.exports = {
   render


### PR DESCRIPTION
Just to give more information -- it appears _within_ the proc for a worker thread things slow down, so need to unpack the overall info more...

Also note this is a breaking change because the scenario API changes from `Promise<string>` to `Promise<{ result<string>, elapsed<Number> }>`